### PR TITLE
fix: boolean options

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -10,8 +10,8 @@ export default async function(context, inject) {
       domainId: '<%= options.domainId %>',
     },
     {
-      ignoreLocalhost: '<%= options.ignoreLocalhost %>',
-      detailed: '<%= options.detailed %>',
+      ignoreLocalhost: <%= options.ignoreLocalhost ? 'true' : 'false' %>,
+      detailed: <%= options.detailed ? 'true' : 'false' %>,
     }
   )
 


### PR DESCRIPTION
not wrap them in a string.

Running:

```js
if('false') {
   console.log("'false' is true")
}
if('true') {
   console.log("'true' is true")
}
```

Will log:
```
'false' is true
'true' is true
```